### PR TITLE
Merge options 'max_depth' and 'max_candidate_size'

### DIFF
--- a/app/configure.cpp
+++ b/app/configure.cpp
@@ -78,7 +78,7 @@ bool t_diag_options::short_opt (int c, char * param) {
         return verb_strtoi(optarg, cutoff->max_candidates, true);
 
     case 'd': // Candidate size cutoff
-        return verb_strtoi(optarg, cutoff->max_candidate_size, true);
+        return verb_strtoi(optarg, cutoff->max_depth, true);
 
     case 'l': // Lambda cutoff
         return verb_strtof(optarg, cutoff->lambda, true);
@@ -133,7 +133,7 @@ std::ostream & t_diag_options::print (std::ostream & out) const {
     out << ", threads: " << threads;
     out << ", cutoff_time: " << cutoff->max_time;
     out << ", cutoff_max_candidates: " << cutoff->max_candidates;
-    out << ", cutoff_max_candidate_size: " << cutoff->max_candidate_size;
+    out << ", cutoff_max_depth: " << cutoff->max_depth;
     out << ", cutoff_lambda: " << cutoff->lambda;
 
 

--- a/common/algorithms/mhs/cutoff.h
+++ b/common/algorithms/mhs/cutoff.h
@@ -28,7 +28,7 @@ public:
                        t_time_interval time_elapsed) const;
 
 public:
-    t_count max_depth, max_candidates, max_candidate_size;
+    t_count max_depth, max_candidates;
     t_time_interval max_time;
     float lambda;
     t_score min_score;


### PR DESCRIPTION
The `-d` command-line argument does not work; even with `-d 1`, the `mhs2` binary will search exhaustively. This appears to be because the value is assigned to `config->max_candidate_size` but then `config->max_depth` is used for testing the relevant condition in the algorithm. This patch merges the two options so that `-d` works properly.
